### PR TITLE
Add recurse option ('-r') to SCP operations

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,4 +46,4 @@ To run tests, simply enter:
 (note that in mocha.opts --timeout is set to 25seconds to test connect fail - you may want to change it depending on your test system).
 
 _Note_: set the `hostname` variable to your server's hostname to succeed with the tests (or add `testhostname` to
-`~/.ssh/config` with the proper settigs).
+`~/.ssh/config` with the proper settings).

--- a/lib/scp.js
+++ b/lib/scp.js
@@ -67,6 +67,10 @@ SCP.prototype.uploadProc = function(localFiles, remotePath) {
 		target = options.hostname + ':' + remotePath;
 	}
 
+    if (!!options.recurse) {
+        scpParams.push('-r');
+    }
+
 	for(switchKey in switchHash) {
 		if(switchHash.hasOwnProperty(switchKey)) {
 			if(options[switchKey]) {
@@ -125,6 +129,10 @@ SCP.prototype.downloadProc = function(remoteFiles, localPath) {
 		//console.log('Local path not exists: ' + localPath);
 		throw new Error('Local path ('+ localPath +') does not exist. Quitting...');
 	}
+
+    if (!!options.recurse) {
+        scpParams.push('-r');
+    }
 
 	for(switchKey in switchHash) {
 		if(switchHash.hasOwnProperty(switchKey)) {


### PR DESCRIPTION
Set options.recurse to truthy to pass the "-r" recurse flag to scp.
