### PR TITLE
Options support for scp

### DIFF
--- a/lib/scp.js
+++ b/lib/scp.js
@@ -60,6 +60,15 @@ SCP.prototype.uploadProc = function(localFiles, remotePath) {
 		throw new Error('Local files don\'t exist. Quitting...');
 	}
 
+    if(options.option) {
+        for(optionKey in options.option) {
+            if(options.option.hasOwnProperty(optionKey)) {
+                scpParams.push('-o');
+                scpParams.push(optionKey + '=' + options.option[optionKey]);
+            }
+        }
+    }
+
 	if(options.user && options.hostname) {
 		target = options.user + '@' + options.hostname + ':' + remotePath;
 	}
@@ -142,6 +151,15 @@ SCP.prototype.downloadProc = function(remoteFiles, localPath) {
 			}
 		}
 	}
+
+    if(options.option) {
+        for(optionKey in options.option) {
+            if(options.option.hasOwnProperty(optionKey)) {
+                scpParams.push('-o');
+                scpParams.push(optionKey + '=' + options.option[optionKey]);
+            }
+        }
+    }
 
 	if(options.user && options.hostname) {
 		remote = options.user + '@' + options.hostname + ':';


### PR DESCRIPTION
### Problem
Using any of the SSH options like StrictHostKeyChecking does not do anything when SCP-ing. 

### Solution
Take these options into account when building the scp child_process command. 